### PR TITLE
Fix background gradient scrolling on body element

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,6 +11,7 @@ html, body {
 body {
   font-family: 'Source Sans Pro', 'Source Sans 3', sans-serif;
   background: linear-gradient(135deg, #002B5B 0%, #6A0DAD 50%, #D10070 100%);
+  background-attachment: fixed;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
Added `background-attachment: fixed` to the body element to prevent the gradient background from scrolling with page content.

## Changes
- Added `background-attachment: fixed` CSS property to the body selector
  - This ensures the gradient background remains fixed to the viewport while content scrolls over it
  - Creates a more polished visual effect where the background stays in place

## Implementation Details
The gradient background on the body element now uses the fixed attachment mode, which is a common pattern for full-page gradient backgrounds. This prevents the background from moving when users scroll, maintaining visual consistency throughout the page navigation.

https://claude.ai/code/session_01ARRxYjDJCGyTsLP2Wbyyut