### PR TITLE
Fix mobile gradient not covering full page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,13 +10,22 @@ html, body {
 
 body {
   font-family: 'Source Sans Pro', 'Source Sans 3', sans-serif;
-  background: linear-gradient(135deg, #002B5B 0%, #6A0DAD 50%, #D10070 100%);
-  background-attachment: fixed;
   display: flex;
   align-items: center;
   justify-content: center;
   min-height: 100vh;
   padding: 24px;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #002B5B 0%, #6A0DAD 50%, #D10070 100%);
+  z-index: -1;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- Fixes the gradient background not extending the full height of the page on mobile (iOS Safari)
- Replaces `background-attachment: fixed` (not supported on iOS Safari) with a `body::before` pseudo-element using `position: fixed` to fill the viewport with the gradient

## Test plan
- [ ] Verify gradient covers full viewport on iOS Safari
- [ ] Verify gradient still looks correct on desktop browsers

https://claude.ai/code/session_01ARRxYjDJCGyTsLP2Wbyyut